### PR TITLE
Optimize the parsing of large templates with nested custom tags and blocks

### DIFF
--- a/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
@@ -3,16 +3,35 @@ lexer grammar LiquidLexer;
 @lexer::members {
   private boolean stripSpacesAroundTags = false;
   private boolean stripSingleLine = false;
+  private java.util.Set<String> blocks = new java.util.HashSet<String>();
+  private java.util.Set<String> tags = new java.util.HashSet<String>();
+  private java.util.Stack<String> customBlockState = new java.util.Stack<String>();
 
-  public LiquidLexer(CharStream charStream, boolean stripSpacesAroundTags) {
-    this(charStream, stripSpacesAroundTags, false);
+  public LiquidLexer(CharStream charStream, boolean stripSpacesAroundTags, java.util.Set<String> blocks, java.util.Set<String> tags) {
+    this(charStream, stripSpacesAroundTags, false, blocks, tags);
   }
 
-  public LiquidLexer(CharStream charStream, boolean stripSpacesAroundTags, boolean stripSingleLine) {
+  public LiquidLexer(CharStream charStream, boolean stripSpacesAroundTags) {
+    this(charStream, stripSpacesAroundTags, false, new java.util.HashSet<String>(), new java.util.HashSet<String>());
+  }
+
+  public LiquidLexer(CharStream charStream, boolean stripSpacesAroundTags, boolean stripSingleLine, java.util.Set<String> blocks, java.util.Set<String> tags) {
       this(charStream);
       this.stripSpacesAroundTags = stripSpacesAroundTags;
       this.stripSingleLine = stripSingleLine;
+      this.blocks = blocks;
+      this.tags = tags;
     }
+
+    // public automatically generated constructor is busted because it doesn't allow for setting block or tags
+}
+
+tokens {
+  BlockId,
+  EndBlockId,
+  SimpleTagId,
+  InvalidEndBlockId,
+  MisMatchedEndBlockId
 }
 
 OutStart
@@ -28,7 +47,7 @@ TagStart
    | WhitespaceChar* '{%' {stripSpacesAroundTags && !stripSingleLine}?
    | WhitespaceChar* '{%-'
    | '{%'
-   ) -> pushMode(IN_TAG)
+   ) -> pushMode(IN_TAG), pushMode(IN_TAG_ID)
  ;
 
 Other
@@ -46,7 +65,6 @@ fragment Digit          : [0-9];
 mode IN_TAG;
 
   OutStart2 : '{{' -> pushMode(IN_TAG);
-  TagStart2 : '{%' -> pushMode(IN_TAG);
 
   OutEnd
    : ( '}}' SpaceOrTab* LineBreak? {stripSpacesAroundTags && stripSingleLine}?
@@ -95,40 +113,90 @@ mode IN_TAG;
 
   WS : WhitespaceChar+ -> channel(HIDDEN);
 
-  CaptureStart : 'capture';
-  CaptureEnd   : 'endcapture';
-  CommentStart : 'comment';
-  CommentEnd   : 'endcomment';
-  RawStart     : 'raw' WhitespaceChar* '%}' -> pushMode(IN_RAW);
-  IfStart      : 'if';
-  Elsif        : 'elsif';
-  IfEnd        : 'endif';
-  UnlessStart  : 'unless';
-  UnlessEnd    : 'endunless';
-  Else         : 'else';
   Contains     : 'contains';
-  CaseStart    : 'case';
-  CaseEnd      : 'endcase';
-  When         : 'when';
-  Cycle        : 'cycle';
-  ForStart     : 'for';
-  ForEnd       : 'endfor';
   In           : 'in';
   And          : 'and';
   Or           : 'or';
-  TableStart   : 'tablerow';
-  TableEnd     : 'endtablerow';
-  Assign       : 'assign';
   True         : 'true';
   False        : 'false';
   Nil          : 'nil' | 'null';
-  Include      : 'include';
   With         : 'with';
   Empty        : 'empty';
   Blank        : 'blank';
-  EndId        : 'end' Id;
 
-  Id : ( Letter | '_' ) (Letter | '_' | '-' | Digit)*;
+  Id : ( Letter | '_' | Digit) (Letter | '_' | '-' | Digit)*;
+
+mode IN_TAG_ID;
+  WS2 : WhitespaceChar+ -> channel(HIDDEN);
+
+  InvalidEndTag
+     : ( '}}' SpaceOrTab* LineBreak? {stripSpacesAroundTags && stripSingleLine}?
+       | '}}' WhitespaceChar* {stripSpacesAroundTags && !stripSingleLine}?
+       | '-}}' WhitespaceChar*
+       | '}}'
+       | '%}' SpaceOrTab* LineBreak? {stripSpacesAroundTags && stripSingleLine}?
+       | '%}' WhitespaceChar* {stripSpacesAroundTags && !stripSingleLine}?
+       | '-%}' WhitespaceChar*
+       | '%}'
+       )
+     ;
+
+  CaptureStart : 'capture' -> popMode;
+  CaptureEnd   : 'endcapture' -> popMode;
+  CommentStart : 'comment' -> popMode;
+  CommentEnd   : 'endcomment' -> popMode;
+  RawStart     : 'raw' WhitespaceChar* '%}' -> popMode, pushMode(IN_RAW);
+  IfStart      : 'if' -> popMode;
+  Elsif        : 'elsif' -> popMode;
+  IfEnd        : 'endif' -> popMode;
+  UnlessStart  : 'unless' -> popMode;
+  UnlessEnd    : 'endunless' -> popMode;
+  Else         : 'else' -> popMode;
+  CaseStart    : 'case' -> popMode;
+  CaseEnd      : 'endcase' -> popMode;
+  When         : 'when' -> popMode;
+  Cycle        : 'cycle' -> popMode;
+  ForStart     : 'for' -> popMode;
+  ForEnd       : 'endfor' -> popMode;
+  TableStart   : 'tablerow' -> popMode;
+  TableEnd     : 'endtablerow' -> popMode;
+  Assign       : 'assign' -> popMode;
+  Include      : 'include' -> popMode;
+
+  InvalidTagId : ( Letter | '_' | Digit ) (Letter | '_' | '-' | Digit)* {
+    String text = getText();
+    if (blocks.contains(text)) {
+      setType(BlockId);
+      customBlockState.push(text);
+    } else if(tags.contains(text)) {
+      setType(SimpleTagId);
+    } else {
+      int length = text.length();
+      if (length > 3 && text.startsWith("end")) {
+        String suffix = text.substring(3);
+        if (!customBlockState.isEmpty()) {
+          String expected = customBlockState.peek();
+          if (blocks.contains(suffix)) {
+            if (expected.equals(suffix)) {
+               customBlockState.pop();
+               setType(EndBlockId);
+            } else {
+              setType(MisMatchedEndBlockId);
+              // this is an invalid end because there was something to end, but it didn't match what we had
+            }
+          } else {
+            setType(InvalidEndBlockId);
+          }
+        } else {
+          // this is an invalid END (because there is nothing to end // but we do know what was expected)
+          setType(InvalidEndBlockId);
+        }
+      } else {
+        // this is an invalid custom tag
+        setType(InvalidTagId);
+      }
+    }
+  } -> popMode;
 
 mode IN_RAW;
 

--- a/src/main/java/liqp/Examples.java
+++ b/src/main/java/liqp/Examples.java
@@ -1,8 +1,10 @@
 package liqp;
 
-import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import liqp.filters.Filter;
 import liqp.nodes.LNode;
+import liqp.tags.Block;
 import liqp.tags.Tag;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,7 +121,7 @@ public class Examples {
 
     private static void customLoopTag() {
 
-        Tag.registerTag(new Tag("loop"){
+        Tag.registerTag(new Block("loop"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
 
@@ -146,10 +148,9 @@ public class Examples {
     }
 
     public static void instanceTag() {
-
         String source = "{% loop 5 %}looping!\n{% endloop %}";
-
-        Template template = Template.parse(source).with(new Tag("loop"){
+        List<Tag> tags = new ArrayList<>();
+        tags.add(new Block("loop"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
 
@@ -166,6 +167,8 @@ public class Examples {
             }
         });
 
+        Template template = Template.parse(source, tags, new ArrayList<Filter>());
+
         String rendered = template.render();
 
         System.out.println(rendered);
@@ -173,7 +176,8 @@ public class Examples {
 
     public static void instanceFilter() {
 
-        Template template = Template.parse("{{ numbers | sum }}").with(new Filter("sum"){
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter("sum"){
             @Override
             public Object apply(Object value, Object... params) {
 
@@ -188,6 +192,8 @@ public class Examples {
                 return sum;
             }
         });
+
+        Template template = Template.parse("{{ numbers | sum }}", new ArrayList<Tag>(), filters);
 
         String rendered = template.render("{\"numbers\" : [1, 2, 3, 4, 5]}");
         System.out.println(rendered);

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -2,12 +2,15 @@ package liqp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.HashSet;
+import java.util.Set;
 import liqp.exceptions.LiquidException;
 import liqp.filters.Filter;
 import liqp.nodes.LNode;
 import liqp.parser.Flavor;
 import liqp.parser.LiquidSupport;
 import liqp.parser.v4.NodeVisitor;
+import liqp.tags.Block;
 import liqp.tags.Include;
 import liqp.tags.Tag;
 import liquid.parser.v4.LiquidLexer;
@@ -73,9 +76,14 @@ public class Template {
         this.filters = filters;
         this.parseSettings = parseSettings;
 
+        // split tags and blocks
+        List<Set<String>> tagsAndBlocks = partitionBlocksAndTags(tags);
+        Set<String> blockNames = tagsAndBlocks.get(0);
+        Set<String> tagNames = tagsAndBlocks.get(1);
+
         CharStream stream = CharStreams.fromString(input);
         this.templateSize = stream.size();
-        LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
+        LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine, blockNames, tagNames);
         try {
             root = parse(lexer);
         }
@@ -93,10 +101,15 @@ public class Template {
         this.filters = filters;
         this.parseSettings = parseSettings;
 
+        // split tags and blocks
+        List<Set<String>> tagsAndBlocks = partitionBlocksAndTags(tags);
+        Set<String> blockNames = tagsAndBlocks.get(0);
+        Set<String> tagNames = tagsAndBlocks.get(1);
+
         try {
             CharStream stream = CharStreams.fromStream(input);
             this.templateSize = stream.size();
-            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
+            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine, blockNames, tagNames);
             root = parse(lexer);
         }
         catch (LiquidException e) {
@@ -104,6 +117,26 @@ public class Template {
         }
         catch (Exception e) {
             throw new RuntimeException("could not parse input: " + input, e);
+        }
+    }
+
+    // main private constructor
+    private Template (CharStream stream, Map<String, Tag> tags, Map<String, Filter> filters, ParseSettings parseSettings) {
+        this.tags = tags;
+        this.filters = filters;
+        this.parseSettings = parseSettings;
+
+        // split tags and blocks
+        List<Set<String>> tagsAndBlocks = partitionBlocksAndTags(tags);
+        Set<String> blockNames = tagsAndBlocks.get(0);
+        Set<String> tagNames = tagsAndBlocks.get(1);
+
+        try {
+            this.templateSize = stream.size();
+            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine, blockNames, tagNames);
+            root = parse(lexer);
+        } catch (LiquidException e) {
+            throw e;
         }
     }
 
@@ -134,20 +167,42 @@ public class Template {
      *         the file holding the Liquid source.
      */
     private Template(File file, Map<String, Tag> tags, Map<String, Filter> filters, ParseSettings parseSettings) throws IOException {
-
         this.tags = tags;
         this.filters = filters;
         this.parseSettings = parseSettings;
         CharStream stream = CharStreams.fromFileName(file.getAbsolutePath());
 
+        // split tags and blocks
+        List<Set<String>> tagsAndBlocks = partitionBlocksAndTags(tags);
+        Set<String> blockNames = tagsAndBlocks.get(0);
+        Set<String> tagNames = tagsAndBlocks.get(1);
+
         try {
             this.templateSize = stream.size();
-            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
+            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine, blockNames, tagNames);
             root = parse(lexer);
         }
         catch (Exception e) {
             throw new RuntimeException("could not parse input from " + file, e);
         }
+    }
+
+    private static List<Set<String>> partitionBlocksAndTags(Map<String, Tag> tags) {
+        Set<String> blockNames = new HashSet<>();
+        Set<String> tagNames = new HashSet<>();
+
+        for (String name : tags.keySet()) {
+            Tag t = tags.get(name);
+            if (t instanceof Block) {
+                blockNames.add(name);
+            } else {
+                tagNames.add(name);
+            }
+        }
+        ArrayList<Set<String>> returnList = new ArrayList<>();
+        returnList.add(blockNames);
+        returnList.add(tagNames);
+        return returnList;
     }
 
     /**
@@ -226,6 +281,24 @@ public class Template {
         return new Template(input, Tag.getTags(), Filter.getFilters(ParseSettings.DEFAULT_FLAVOR), new ParseSettings.Builder().build());
     }
 
+  /**
+   * Returns a new Template instance from a given input string with a specified set of
+   * tags and filters
+   *
+   * @param input
+   *         the input string holding the Liquid source.
+   * @param tags
+   *         the list of tags to use when parsing and rendering the template
+   * @param filters
+   *         the list of filters to use when parsing and rendering the template
+   *
+   * @return a new Template instance from a given input string.
+   */
+    public static Template parse(String input, List<Tag> tags, List<Filter> filters) {
+
+        return parse(input, tags, filters, new ParseSettings.Builder().build(), new RenderSettings.Builder().build());
+    }
+
     /**
      * Returns a new Template instance from a given input file.
      *
@@ -270,14 +343,18 @@ public class Template {
         return parse(input, settings);
     }
 
-    public Template with(Tag tag) {
-        this.tags.put(tag.name, tag);
-        return this;
-    }
+    public static Template parse(String input, List<Tag> tags, List<Filter> filters, ParseSettings parseSettings, RenderSettings renderSettings) {
+      Map<String, Tag> tagMap = new HashMap<>();
+      for (Tag tag : tags) {
+        tagMap.put(tag.name, tag);
+      }
 
-    public Template with(Filter filter) {
-        this.filters.put(filter.name, filter);
-        return this;
+      Map<String, Filter> filterMap = new HashMap<>();
+      for (Filter filter: filters) {
+        filterMap.put(filter.name, filter);
+      }
+
+      return new Template(input, tagMap, filterMap, parseSettings, renderSettings);
     }
 
     public Template withProtectionSettings(ProtectionSettings protectionSettings) {

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -37,6 +37,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
       throw new IllegalArgumentException("parseSettings == null");
 
     this.tags = tags;
+
     this.filters = filters;
     this.parseSettings = parseSettings;
   }
@@ -87,6 +88,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
   //  ;
   @Override
   public LNode visitOther_tag(Other_tagContext ctx) {
+    String blockId = ctx.BlockId().getText();
 
     List<LNode> expressions = new ArrayList<LNode>();
 
@@ -94,26 +96,27 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
       expressions.add(new AtomNode(ctx.other_tag_parameters().getText()));
     }
 
-    if (ctx.other_tag_block() != null) {
-      expressions.add(visitOther_tag_block(ctx.other_tag_block()));
-    }
-
-    return new TagNode(tags.get(ctx.Id().getText()), expressions.toArray(new LNode[expressions.size()]));
-  }
-
-  // custom_tag_block
-  //  : atom+? tagStart EndId TagEnd
-  //  ;
-  @Override
-  public BlockNode visitOther_tag_block(Other_tag_blockContext ctx) {
-
     BlockNode node = new BlockNode(isRootBlock);
 
     for (AtomContext child : ctx.atom()) {
       node.add(visit(child));
     }
 
-    return node;
+    expressions.add(node);
+
+    return new TagNode(tags.get(blockId), expressions.toArray(new LNode[expressions.size()]));
+  }
+
+  @Override
+  public LNode visitSimple_tag(Simple_tagContext ctx) {
+
+    List<LNode> expressions = new ArrayList<LNode>();
+
+    if (ctx.other_tag_parameters() != null) {
+      expressions.add(new AtomNode(ctx.other_tag_parameters().getText()));
+    }
+
+    return new TagNode(tags.get(ctx.SimpleTagId().getText()), expressions.toArray(new LNode[expressions.size()]));
   }
 
   // raw_tag

--- a/src/main/java/liqp/tags/Block.java
+++ b/src/main/java/liqp/tags/Block.java
@@ -1,0 +1,21 @@
+package liqp.tags;
+
+public abstract class Block extends Tag {
+    /**
+     * Used for all package protected blocks in the liqp.tags-package
+     * whose name is their class name lower cased.
+     */
+    protected Block() {
+        super();
+    }
+
+    /**
+     * Creates a new instance of a Block.
+     *
+     * @param name
+     *         the name of the block.
+     */
+    public Block(String name) {
+        super(name);
+    }
+}

--- a/src/main/java/liqp/tags/Capture.java
+++ b/src/main/java/liqp/tags/Capture.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Capture extends Tag {
+class Capture extends Block {
 
     /*
      * Block tag that captures text into a variable

--- a/src/main/java/liqp/tags/Case.java
+++ b/src/main/java/liqp/tags/Case.java
@@ -5,7 +5,7 @@ import liqp.TemplateContext;
 import liqp.nodes.BlockNode;
 import liqp.nodes.LNode;
 
-class Case extends Tag {
+class Case extends Block {
 
     /*
      * Block tag, its the standard case...when block

--- a/src/main/java/liqp/tags/Comment.java
+++ b/src/main/java/liqp/tags/Comment.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Comment extends Tag {
+class Comment extends Block {
 
     /*
      * Block tag, comments out the text in the block

--- a/src/main/java/liqp/tags/Cycle.java
+++ b/src/main/java/liqp/tags/Cycle.java
@@ -6,7 +6,7 @@ import liqp.nodes.LNode;
 import java.util.ArrayList;
 import java.util.List;
 
-class Cycle extends Tag {
+class Cycle extends Block {
 
     private static final String PREPEND = "\"'";
 

--- a/src/main/java/liqp/tags/For.java
+++ b/src/main/java/liqp/tags/For.java
@@ -12,7 +12,7 @@ import liqp.nodes.LNode;
 import java.util.HashMap;
 import java.util.Map;
 
-class For extends Tag {
+class For extends Block {
 
     private static final String OFFSET = "offset";
     private static final String LIMIT = "limit";

--- a/src/main/java/liqp/tags/If.java
+++ b/src/main/java/liqp/tags/If.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class If extends Tag {
+class If extends Block {
 
     /*
      * Standard if/else block

--- a/src/main/java/liqp/tags/Ifchanged.java
+++ b/src/main/java/liqp/tags/Ifchanged.java
@@ -5,7 +5,7 @@ import liqp.nodes.LNode;
 
 import java.util.*;
 
-public class Ifchanged extends Tag {
+public class Ifchanged extends Block {
 
     private static final String TEMP_SET_KEY = "@ifchanged";
 

--- a/src/main/java/liqp/tags/Raw.java
+++ b/src/main/java/liqp/tags/Raw.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Raw extends Tag {
+class Raw extends Block {
 
     /*
      * temporarily disable tag processing to avoid syntax conflicts.

--- a/src/main/java/liqp/tags/Tablerow.java
+++ b/src/main/java/liqp/tags/Tablerow.java
@@ -6,7 +6,7 @@ import liqp.nodes.LNode;
 import java.util.HashMap;
 import java.util.Map;
 
-class Tablerow extends Tag {
+class Tablerow extends Block {
 
     private static final String COLS = "cols";
     private static final String LIMIT = "limit";

--- a/src/main/java/liqp/tags/Tag.java
+++ b/src/main/java/liqp/tags/Tag.java
@@ -61,12 +61,12 @@ public abstract class Tag extends LValue {
     }
 
     /**
-     * Retrieves a filter with a specific name.
+     * Retrieves a tag with a specific name.
      *
      * @param name
-     *         the name of the filter to retrieve.
+     *         the name of the tag to retrieve.
      *
-     * @return a filter with a specific name.
+     * @return a tag with a specific name.
      */
     public static Tag getTag(String name) {
 

--- a/src/main/java/liqp/tags/Unless.java
+++ b/src/main/java/liqp/tags/Unless.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Unless extends Tag {
+class Unless extends Block {
 
     /*
      * Mirror of if statement

--- a/src/test/java/liqp/nodes/BlockNodeTest.java
+++ b/src/test/java/liqp/nodes/BlockNodeTest.java
@@ -2,6 +2,7 @@ package liqp.nodes;
 
 import liqp.Template;
 import liqp.TemplateContext;
+import liqp.tags.Block;
 import liqp.tags.Tag;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class BlockNodeTest {
     @Test
     public void customTagTest() throws RecognitionException {
 
-        Tag.registerTag(new Tag("testtag"){
+        Tag.registerTag(new Block("testtag"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
                 return null;

--- a/src/test/java/liqp/parser/ParseTest.java
+++ b/src/test/java/liqp/parser/ParseTest.java
@@ -1,7 +1,11 @@
 package liqp.parser;
 
 import liqp.Template;
+import liqp.TemplateContext;
 import liqp.exceptions.LiquidException;
+import liqp.nodes.LNode;
+import liqp.tags.Block;
+import liqp.tags.Tag;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/TagTest.java
+++ b/src/test/java/liqp/tags/TagTest.java
@@ -10,10 +10,30 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class TagTest {
+    @Test
+    public void testNestedCustomTagsAndBlocks() {
+        Tag.registerTag(new Block("block") {
+            @Override
+            public Object render(TemplateContext context, LNode... nodes) {
+                String data = (nodes.length >= 2 ? nodes[1].render(context) : nodes[0].render(context)).toString();
+
+                return "blk[" + data + "]";
+            }
+        });
+
+        Tag.registerTag(new Tag("simple") {
+            @Override
+            public Object render(TemplateContext context, LNode... nodes) {
+                return "(sim)";
+            }
+        });
+        String templateString = "{% block %}a{% simple %}b{% block %}c{% endblock %}d{% endblock %}";
+        Template template = Template.parse(templateString);
+        assertThat("blk[a(sim)bblk[c]d]", is(template.render()));
+    }
 
     @Test
     public void testCustomTag() throws RecognitionException {
-
         Tag.registerTag(new Tag("twice") {
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
@@ -31,7 +51,7 @@ public class TagTest {
     @Test
     public void testCustomTagBlock() throws RecognitionException {
 
-        Tag.registerTag(new Tag("twice") {
+        Tag.registerTag(new Block("twice") {
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
                 LNode blockNode = nodes[nodes.length - 1];


### PR DESCRIPTION
Definitely makes some significant breaking changes to the API due to the differentiation between
blocks and tags. The tags and blocks are passed to the lexer for an optimized parse that doesn't
fall back to the LL(*) parser (which is significantly slower than the SLL(*) parser mode).

Adds some error handling for mismatched tags and broken templates. Removed a few edges around open ({{)
and close (}}) tags.